### PR TITLE
feat(health): enhance /health route with detailed system info

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,8 +1,29 @@
 import express, { Application, Request, Response } from 'express';
+import mongoose from 'mongoose';
 import { errorHandler } from '@shared/middlewares/errorHandler';
 import logger from '@shared/utils/logger';
 import config from '@shared/config/env';
 import { authRouter } from '@modules/auth';
+
+interface HealthStatus {
+  status: 'ok' | 'degraded' | 'unhealthy';
+  uptime: number;
+  memory: {
+    heapUsed: number;
+    heapTotal: number;
+    external: number;
+    rss: number;
+  };
+  database: {
+    state: string;
+    connected: boolean;
+  };
+  environment: {
+    nodeEnv: string;
+    appName: string;
+  };
+  timestamp: string;
+}
 
 const app: Application = express();
 
@@ -18,13 +39,37 @@ app.use((req: Request, res: Response, next) => {
 });
 
 app.get('/health', (_req: Request, res: Response) => {
-  res.status(200).json({
-    status: 'ok',
-    message: 'Server is running',
-    app: config.get().appName,
-    environment: config.get().nodeEnv,
-    timestamp: new Date().toISOString()
-  });
+  const dbState = mongoose.connection.readyState;
+  const dbStates: Record<number, string> = {
+    0: 'disconnected',
+    1: 'connected',
+    2: 'connecting',
+    3: 'disconnecting',
+  };
+
+  const memoryUsage = process.memoryUsage();
+
+  const health: HealthStatus = {
+    status: dbState === 1 ? 'ok' : 'degraded',
+    uptime: process.uptime(),
+    memory: {
+      heapUsed: Math.round(memoryUsage.heapUsed / 1024 / 1024),
+      heapTotal: Math.round(memoryUsage.heapTotal / 1024 / 1024),
+      external: Math.round(memoryUsage.external / 1024 / 1024),
+      rss: Math.round(memoryUsage.rss / 1024 / 1024),
+    },
+    database: {
+      state: dbStates[dbState] ?? 'unknown',
+      connected: dbState === 1,
+    },
+    environment: {
+      nodeEnv: config.get().nodeEnv,
+      appName: config.get().appName,
+    },
+    timestamp: new Date().toISOString(),
+  };
+
+  res.status(health.status === 'ok' ? 200 : 503).json(health);
 });
 
 app.use('/auth', authRouter);


### PR DESCRIPTION
## Summary
- Enhanced `/health` route with detailed system information including uptime, memory usage (heap/rss), database connection state, and environment info
- Returns `503 Service Unavailable` when database is not connected (degraded status)
- All memory values returned in MB for readability

## Test plan
- [ ] Verify `/health` returns all new fields: `uptime`, `memory`, `database`, `environment`
- [ ] Verify `503` status when MongoDB is disconnected
- [ ] Verify `200` status when MongoDB is connected

Closes #3